### PR TITLE
fix: player death listener keepinventory

### DIFF
--- a/src/main/java/me/ShermansWorld/raidsperregion/listeners/PlayerDeathListener.java
+++ b/src/main/java/me/ShermansWorld/raidsperregion/listeners/PlayerDeathListener.java
@@ -5,28 +5,22 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
-import org.bukkit.inventory.ItemStack;
 
 import me.ShermansWorld.raidsperregion.RaidsPerRegion;
 import me.ShermansWorld.raidsperregion.config.Config;
 import me.ShermansWorld.raidsperregion.raid.Raid;
 import me.ShermansWorld.raidsperregion.raid.Raids;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class PlayerDeathListener implements Listener {
 	@EventHandler
 	public void onPlayerDeath(PlayerDeathEvent e){
+		Player p = e.getPlayer();
+
 		if (Config.keepInventoryInRaids) {
-			Player p = (Player) e.getEntity();
-			List<ItemStack> drops = new ArrayList<>(e.getDrops());
-			Object[] array = drops.toArray();
 			for (Raid regionRaid : Raids.activeRegionRaids) {
 				if (regionRaid.getActiveParticipants().contains(p.getUniqueId())) {
 					e.setKeepInventory(true);
 					e.getDrops().clear();
-					p.getInventory().setContents((ItemStack[])array);
 				}
 			}
 			if (RaidsPerRegion.isUsingTowny) {
@@ -34,14 +28,12 @@ public class PlayerDeathListener implements Listener {
 					if (townRaid.getActiveParticipants().contains(p.getUniqueId())) {
 						e.setKeepInventory(true);
 						e.getDrops().clear();
-						p.getInventory().setContents((ItemStack[])array);
 					}
 				}
 			}
-			drops.clear();
 		}
+
 		if (Config.keepXPInRaids) {
-			Player p = (Player) e.getEntity();
 			for (Raid regionRaid : Raids.activeRegionRaids) {
 				if (regionRaid.getActiveParticipants().contains(p.getUniqueId())) {
 					e.setKeepLevel(true);

--- a/src/main/java/me/ShermansWorld/raidsperregion/raid/RegionRaid.java
+++ b/src/main/java/me/ShermansWorld/raidsperregion/raid/RegionRaid.java
@@ -139,28 +139,27 @@ public class RegionRaid extends Raid {
 
 	@Override
 	public void findParticipants() {
-		for (Player player : Bukkit.getOnlinePlayers()) {
-			Location loc = player.getLocation();
+		for (Player p : Bukkit.getOnlinePlayers()) {
+			Location loc = p.getLocation();
+
 			if (region.contains(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ())) {
-				if (!super.getParticipantsKillsMap().containsKey(player.getUniqueId())) {
-					super.getParticipantsKillsMap().put(player.getUniqueId(), 0);
-					super.sendTitleToPlayer(player, Config.raidStartTitle, Config.raidStartSubtitle);
+				if (!getParticipantsKillsMap().containsKey(p.getUniqueId())) {
+					getParticipantsKillsMap().put(p.getUniqueId(), 0);
+					sendTitleToPlayer(p, Config.raidStartTitle, Config.raidStartSubtitle);
+
 					// Show scoreboard after title goes away
-					new BukkitRunnable() {
-						public void run() {
-							// Show scoreboard after title goes away
-							createScoreboard(player);
-							updateScoreboard(player);
-						}
-					}.runTaskLater(RaidsPerRegion.getInstance(), 80);
+					Bukkit.getScheduler().runTaskLater(RaidsPerRegion.getInstance(), () -> {
+						createScoreboard(p);
+						updateScoreboard(p);
+					}, 80);
 				}
-				if (!super.getActiveParticipants().contains(player.getUniqueId())) {
-					super.getActiveParticipants().add(player.getUniqueId());
+
+				// Add player to raid if not in it already
+				if (!getActiveParticipants().contains(p.getUniqueId())) {
+					getActiveParticipants().add(p.getUniqueId());
 				}
 			} else {
-				if (super.getActiveParticipants().contains(player.getUniqueId())) {
-					super.getActiveParticipants().remove(player.getUniqueId());
-				}
+                getActiveParticipants().remove(p.getUniqueId()); // Remove from raid if in it
 			}
 		}
 	}

--- a/src/main/java/me/ShermansWorld/raidsperregion/towny/TownRaid.java
+++ b/src/main/java/me/ShermansWorld/raidsperregion/towny/TownRaid.java
@@ -142,24 +142,25 @@ public class TownRaid extends Raid {
 
 	@Override
 	public void findParticipants() {
-		for (Player p : Bukkit.getOnlinePlayers()) {
-			final Location pLocation = p.getLocation();
+		// Get town home-block
+		TownBlock townBlock = town.getHomeBlockOrNull();
+		if (townBlock == null)
+			return;
 
-			// Get town home-block
-			TownBlock townBlock = town.getHomeBlockOrNull();
-			if (townBlock == null)
-				continue;
+		World townWorld = townBlock.getWorld().getBukkitWorld();
+		Location locLower = townBlock.getWorldCoord().getLowerMostCornerLocation();
+		Location locUpper = townBlock.getWorldCoord().getUpperMostCornerLocation();
+		Location townCenter = locLower.toVector().getMidpoint(locUpper.toVector()).toLocation(townWorld);
+
+		for (Player p : Bukkit.getOnlinePlayers()) {
+			Location pLocation = p.getLocation();
 
 			// Check if player and town is in same world
-			World townWorld = townBlock.getWorld().getBukkitWorld();
 			if (pLocation.getWorld() == null || !pLocation.getWorld().equals(townWorld))
 				continue;
 
-			// Calculate player distance from center of town home-block
-			Location locLower = townBlock.getWorldCoord().getLowerMostCornerLocation();
-			Location locUpper = townBlock.getWorldCoord().getUpperMostCornerLocation();
-			final Location townCenter = locLower.toVector().getMidpoint(locUpper.toVector()).toLocation(townWorld);
-			final double distance = townCenter.distance(pLocation);
+			// Calculate player distance from center of town center
+			double distance = townCenter.distance(pLocation);
 
             // Outside range of raid
             if (distance < RAID_MAX_RANGE) { // In range of raid


### PR DESCRIPTION
- This fixes the keep inventory issue. 
- Players are now counted as part of a town raid if they are sufficiently close to the town. (*500 blocks*)